### PR TITLE
fix: disable experimental warning and open port automatically

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,7 @@
 module.exports = {
   poweredByHeader: false,
   trailingSlash: true,
-  experimental: {
-    newNextLinkBehavior: true,
-  },
+
   webpack(config) {
     // https://github.com/vercel/next.js/issues/25950#issuecomment-863298702
     const fileLoaderRule = config.module.rules.find((rule) => rule.test && rule.test.test('.svg'));

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "npm": ">=8.6.0"
   },
   "scripts": {
-    "dev": "next dev",
+    "dev": "npm run open-browser && next dev", 
+    "open-browser": "open http://localhost:3000",
     "build": "next build",
     "start": "next start",
     "setup:onboarding:env": "node src/scripts/setup-env.files.js",

--- a/src/components/shared/header/header.jsx
+++ b/src/components/shared/header/header.jsx
@@ -30,7 +30,6 @@ const Header = () => {
     <header className="safe-paddings">
       <div className="container flex items-center py-8">
         <Link className="mx-3 sm:ml-0" to="/">
-          <span className="sr-only">Acme corporation logo</span>
           <Logo className="w-[150px] sm:w-[120px]" />
         </Link>
         <NavigationIllustration className="mx-8 max-w-[510px] lg:max-w-[300px] md:hidden" />


### PR DESCRIPTION
fixes [NV-1865](https://linear.app/novu/issue/NV-1865/inapp-demo-app)

1. Remove experimental config from next.config.js
2. Remove extra span in Link to fix [this error](https://nextjs.org/docs/messages/link-multiple-children)
3. Add script to open website on port 3000 automatically.